### PR TITLE
acerto aplication 9093

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 spring.application.name=TechChallenge
-server.port = 9090
+server.port = 9093
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
 spring.datasource.url=jdbc:mysql://localhost:3307/tech_challenge
 spring.datasource.username=root2


### PR DESCRIPTION
notei que haviamos combinado a porta 9093, porem o documento estava ainda com a porta 9090 dando erro nas chamadas. quando seguimos os procedimentos para subir a aplicacao. 